### PR TITLE
Add ghcjs repository

### DIFF
--- a/ubuntu.json
+++ b/ubuntu.json
@@ -258,6 +258,10 @@
     "sourceline": "ppa:hvr/ghc"
   },
   {
+    "alias": "hvr-ghcjs",
+    "sourceline": "ppa:hvr/ghcjs"
+  },  
+  {
     "alias": "kalakris-cmake",
     "sourceline": "ppa:kalakris/cmake"
   },


### PR DESCRIPTION
Add ghcjs repository to the whitelist in addition to ghc repository for testing Haskell-javascript builds